### PR TITLE
refactor: reduce redundancy across voting methods and renderer

### DIFF
--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -1,3 +1,5 @@
+const CROWN_SVG = ' <svg class="winner-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M2 19h20l-2-10-5 5-3-8-3 8-5-5z"/><rect x="2" y="20" width="20" height="2" rx="1"/></svg>';
+
 let lastResult = null;
 let electionCount = 0;
 let parsedCandidates = [];
@@ -537,67 +539,7 @@ function displayResults(result) {
     return;
   }
 
-  result.rounds.forEach(round => {
-    const card = document.createElement('div');
-    card.className = 'round-card';
-
-    const eliminatedSet = new Set(round.eliminated || []);
-    const electedSet = new Set(round.elected || []);
-
-    let rankTableHTML = '';
-    if (round.rankDistribution) {
-      const candidates = Object.keys(round.rankDistribution).sort((a, b) => {
-        const aFirst = round.rankDistribution[a][0] || 0;
-        const bFirst = round.rankDistribution[b][0] || 0;
-        return bFirst - aFirst;
-      });
-      const numPositions = Math.max(...candidates.map(c => round.rankDistribution[c].length));
-
-      let headerCells = '<th>Candidate</th>';
-      for (let i = 0; i < numPositions; i++) {
-        headerCells += `<th>${i + 1}${ordinalSuffix(i + 1)}</th>`;
-      }
-
-      let bodyRows = '';
-      for (const candidate of candidates) {
-        const counts = round.rankDistribution[candidate];
-        const isElected = electedSet.has(candidate);
-        const crownHTML = isElected ? ' <svg class="winner-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M2 19h20l-2-10-5 5-3-8-3 8-5-5z"/><rect x="2" y="20" width="20" height="2" rx="1"/></svg>' : '';
-        let cells = `<td class="rank-table-candidate${isElected ? ' borda-winner-label' : ''}">${candidate}${crownHTML}</td>`;
-        for (let i = 0; i < numPositions; i++) {
-          const count = counts[i] || 0;
-          const isFirst = i === 0;
-          cells += `<td class="${isFirst ? 'rank-first' : ''}">${count}</td>`;
-        }
-        const trClass = eliminatedSet.has(candidate) ? ' class="eliminated-row"' : '';
-        bodyRows += `<tr${trClass}>${cells}</tr>`;
-      }
-
-      rankTableHTML = `
-        <div class="rank-table-wrapper">
-          <h5>Ranking Distribution</h5>
-          <table class="rank-table">
-            <thead><tr>${headerCells}</tr></thead>
-            <tbody>${bodyRows}</tbody>
-          </table>
-        </div>`;
-    }
-
-    let statusHTML = '';
-    if (round.elected && round.elected.length > 0) {
-      statusHTML = `<p class="winner-text">Elected: ${round.elected.join(', ')}</p>`;
-    }
-    if (round.eliminated) {
-      statusHTML += `<p class="eliminated-text">Eliminated: ${round.eliminated.join(', ')}</p>`;
-    }
-
-    card.innerHTML = `
-      <h4>Round ${round.roundNumber}</h4>
-      ${rankTableHTML}
-      ${statusHTML}`;
-
-    container.appendChild(card);
-  });
+  renderIRVRounds(result, container);
 }
 
 function displayBordaBreakdown(result, container) {
@@ -621,7 +563,7 @@ function displayBordaBreakdown(result, container) {
   for (const candidate of candidates) {
     const isWinner = winnerSet.has(candidate);
     const dist = rankDist[candidate] || [];
-    const crownHTML = isWinner ? ' <svg class="winner-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M2 19h20l-2-10-5 5-3-8-3 8-5-5z"/><rect x="2" y="20" width="20" height="2" rx="1"/></svg>' : '';
+    const crownHTML = isWinner ? CROWN_SVG : '';
     let cells = `<td class="rank-table-candidate${isWinner ? ' borda-winner-label' : ''}">${candidate}${crownHTML}</td>`;
     for (let i = 0; i < numPositions; i++) {
       cells += `<td>${dist[i] || 0}</td>`;
@@ -682,7 +624,7 @@ function displayPreferentialBlockBreakdown(result, container) {
         const totalCounted = round.tallies[candidate] || 0;
 
         const nameClass = `rank-table-candidate${isElected ? ' pbv-winner-label' : ''}`;
-        const crownHTML = isElected ? ' <svg class="winner-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M2 19h20l-2-10-5 5-3-8-3 8-5-5z"/><rect x="2" y="20" width="20" height="2" rx="1"/></svg>' : '';
+        const crownHTML = isElected ? CROWN_SVG : '';
         let cells = `<td class="${nameClass}">${candidate}${crownHTML}</td>`;
         for (let i = 0; i < numPositions; i++) {
           const count = counts[i] || 0;
@@ -880,7 +822,7 @@ function displayMultiPositionResults(results) {
       posBody.appendChild(statsEl);
 
       if (result.method === 'irv') {
-        displayIRVRounds(result, posBody);
+        renderIRVRounds(result, posBody);
       } else if (result.method === 'borda') {
         displayBordaResults(result, posBody);
       } else if (result.method === 'preferential-block') {
@@ -922,8 +864,7 @@ function displayMultiPositionResults(results) {
   container.appendChild(panelsWrapper);
 }
 
-// Helper functions to display IRV and Borda results for multi-position
-function displayIRVRounds(result, container) {
+function renderIRVRounds(result, container) {
   result.rounds.forEach(round => {
     const card = document.createElement('div');
     card.className = 'round-card';
@@ -933,7 +874,9 @@ function displayIRVRounds(result, container) {
 
     let rankTableHTML = '';
     if (round.rankDistribution) {
-      const candidates = Object.keys(round.rankDistribution);
+      const candidates = Object.keys(round.rankDistribution).sort((a, b) => {
+        return (round.rankDistribution[b][0] || 0) - (round.rankDistribution[a][0] || 0);
+      });
       const numPositions = Math.max(...candidates.map(c => round.rankDistribution[c].length));
 
       let headerCells = '<th>Candidate</th>';
@@ -946,14 +889,13 @@ function displayIRVRounds(result, container) {
       for (const candidate of candidates) {
         const counts = round.rankDistribution[candidate];
         const isElected = electedSet.has(candidate);
-        const crownHTML = isElected ? ' <svg class="winner-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M2 19h20l-2-10-5 5-3-8-3 8-5-5z"/><rect x="2" y="20" width="20" height="2" rx="1"/></svg>' : '';
+        const crownHTML = isElected ? CROWN_SVG : '';
         let cells = `<td class="rank-table-candidate${isElected ? ' borda-winner-label' : ''}">${candidate}${crownHTML}</td>`;
         let total = 0;
         for (let i = 0; i < numPositions; i++) {
           const count = counts[i] || 0;
           total += count;
-          const isFirst = i === 0;
-          cells += `<td class="${isFirst ? 'rank-first' : ''}">${count}</td>`;
+          cells += `<td class="${i === 0 ? 'rank-first' : ''}">${count}</td>`;
         }
         cells += `<td class="rank-total">${total}</td>`;
         const trClass = eliminatedSet.has(candidate) ? ' class="eliminated-row"' : '';
@@ -1007,7 +949,7 @@ function displayBordaResults(result, container) {
   for (const [candidate, ] of sortedEntries) {
     const dist = distribution[candidate] || [];
     const isWinner = winnerSet.has(candidate);
-    const crownHTML = isWinner ? ' <svg class="winner-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M2 19h20l-2-10-5 5-3-8-3 8-5-5z"/><rect x="2" y="20" width="20" height="2" rx="1"/></svg>' : '';
+    const crownHTML = isWinner ? CROWN_SVG : '';
     let cells = `<td class="rank-table-candidate ${isWinner ? 'borda-winner' : ''}">${candidate}${crownHTML}</td>`;
     for (let i = 1; i <= numCandidates; i++) {
       cells += `<td>${dist[i] || 0}</td>`;

--- a/src/voting/BordaCountMethod.js
+++ b/src/voting/BordaCountMethod.js
@@ -5,46 +5,6 @@ class BordaCountMethod extends VotingMethod {
     super('borda');
   }
 
-  validate(candidates, ballots) {
-    const errors = [];
-
-    if (!Array.isArray(candidates) || candidates.length === 0) {
-      errors.push('Candidates list must be a non-empty array');
-    }
-
-    if (!Array.isArray(ballots) || ballots.length === 0) {
-      errors.push('Ballots list must be a non-empty array');
-    }
-
-    if (errors.length > 0) {
-      return { valid: false, errors };
-    }
-
-    const candidateSet = new Set(candidates);
-
-    for (let i = 0; i < ballots.length; i++) {
-      const ballot = ballots[i];
-
-      if (!Array.isArray(ballot) || ballot.length === 0) {
-        errors.push(`Ballot ${i + 1}: must be a non-empty array`);
-        continue;
-      }
-
-      const seen = new Set();
-      for (const choice of ballot) {
-        if (!candidateSet.has(choice)) {
-          errors.push(`Ballot ${i + 1}: unknown candidate "${choice}"`);
-        }
-        if (seen.has(choice)) {
-          errors.push(`Ballot ${i + 1}: duplicate ranking for "${choice}"`);
-        }
-        seen.add(choice);
-      }
-    }
-
-    return { valid: errors.length === 0, errors };
-  }
-
   tabulate(candidates, ballots, seats = 1) {
     if (seats === 1) {
       return this._tabulateSingleWinner(candidates, ballots);
@@ -52,26 +12,24 @@ class BordaCountMethod extends VotingMethod {
     return this._tabulateMultiWinner(candidates, ballots, seats);
   }
 
-  // Borda Count — single winner
-  _tabulateSingleWinner(candidates, ballots) {
+  _computeScores(candidates, ballots) {
     const scores = {};
-    for (const candidate of candidates) {
-      scores[candidate] = 0;
-    }
-
-    // Assign points based on ranking position
-    // 1st choice gets (n-1) points, 2nd gets (n-2), etc.
+    for (const candidate of candidates) scores[candidate] = 0;
     for (const ballot of ballots) {
       for (let position = 0; position < ballot.length; position++) {
         const candidate = ballot[position];
-        if (candidates.includes(candidate)) {
-          const points = Math.max(0, candidates.length - 1 - position);
-          scores[candidate] += points;
+        if (scores[candidate] !== undefined) {
+          scores[candidate] += Math.max(0, candidates.length - 1 - position);
         }
       }
     }
+    return scores;
+  }
 
-    // Find winner(s)
+  // Borda Count — single winner
+  _tabulateSingleWinner(candidates, ballots) {
+    const scores = this._computeScores(candidates, ballots);
+
     const maxScore = Math.max(...Object.values(scores));
     const winners = Object.entries(scores)
       .filter(([, score]) => score === maxScore)
@@ -86,10 +44,8 @@ class BordaCountMethod extends VotingMethod {
       method: 'borda',
       title: '',
       winners,
-      elected: winners,
       scores,
       rankDistribution: this._computeRankDistribution(candidates, ballots),
-      // renderer-compatible fields
       isTie,
       summary,
       totalBallots: ballots.length,
@@ -103,97 +59,43 @@ class BordaCountMethod extends VotingMethod {
         totalActiveBallots: ballots.length,
         threshold: null,
       }],
-      // kept for backwards compatibility
-      isTieBreak: isTie,
-      results: scores,
-      ballotCount: ballots.length,
-      candidateCount: candidates.length,
-      timestamp: new Date().toISOString(),
+      timestamp: '',
     };
   }
 
   // Borda Count — multi-winner (top-N by total score)
   _tabulateMultiWinner(candidates, ballots, seats) {
-    const scores = {};
-    for (const candidate of candidates) {
-      scores[candidate] = 0;
-    }
+    const scores = this._computeScores(candidates, ballots);
 
-    // Calculate Borda scores using fixed point scale (based on total candidates)
-    // All candidates scored consistently: 1st choice = n-1 points, etc.
-    for (const ballot of ballots) {
-      for (let position = 0; position < ballot.length; position++) {
-        const candidate = ballot[position];
-        if (candidates.includes(candidate)) {
-          const points = Math.max(0, candidates.length - 1 - position);
-          scores[candidate] += points;
-        }
-      }
-    }
-
-    // Sort all candidates by score (descending)
     const sortedCandidates = Object.entries(scores)
-      .sort(([, scoreA], [, scoreB]) => scoreB - scoreA);
+      .sort(([, a], [, b]) => b - a);
 
-    // Elect top N candidates for the available seats
-    const elected = [];
-    const rounds = [];
-    
-    for (let i = 0; i < Math.min(seats, sortedCandidates.length); i++) {
-      const [candidate, score] = sortedCandidates[i];
-      elected.push(candidate);
-      
-      rounds.push({
-        roundNumber: i + 1,
-        seat: i + 1,
-        elected: [candidate],
-        score: score,
-        allScores: { ...scores },
-        // renderer-compatible fields
-        tallies: { ...scores },
-        totalActiveBallots: ballots.length,
-        threshold: null,
-      });
-    }
+    const winners = sortedCandidates.slice(0, seats).map(([c]) => c);
+    const rounds = winners.map((candidate, i) => ({
+      roundNumber: i + 1,
+      seat: i + 1,
+      elected: [candidate],
+      tallies: { ...scores },
+      totalActiveBallots: ballots.length,
+      threshold: null,
+    }));
 
     return {
       method: 'borda',
       title: '',
-      elected,
-      winners: elected,
+      winners,
       rounds,
       scores,
       rankDistribution: this._computeRankDistribution(candidates, ballots),
-      // renderer-compatible fields
       isTie: false,
-      summary: `${elected.length} seats filled: ${elected.join(', ')}.`,
+      summary: `${winners.length} seats filled: ${winners.join(', ')}.`,
       totalBallots: ballots.length,
       totalCandidates: candidates.length,
       exhaustedBallots: 0,
-      // kept for backwards compatibility
-      ballotCount: ballots.length,
-      candidateCount: candidates.length,
-      seatsToFill: seats,
-      seatsElected: elected.length,
-      timestamp: new Date().toISOString(),
+      timestamp: '',
     };
   }
 
-  _computeRankDistribution(candidates, ballots) {
-    const distribution = {};
-    for (const c of candidates) {
-      distribution[c] = new Array(candidates.length).fill(0);
-    }
-    for (const ballot of ballots) {
-      for (let i = 0; i < ballot.length; i++) {
-        const candidate = ballot[i];
-        if (distribution[candidate] !== undefined) {
-          distribution[candidate][i]++;
-        }
-      }
-    }
-    return distribution;
-  }
 }
 
 module.exports = BordaCountMethod;

--- a/src/voting/IRVMethod.js
+++ b/src/voting/IRVMethod.js
@@ -5,46 +5,6 @@ class IRVMethod extends VotingMethod {
     super('irv');
   }
 
-  validate(candidates, ballots) {
-    const errors = [];
-
-    if (!Array.isArray(candidates) || candidates.length === 0) {
-      errors.push('Candidates list must be a non-empty array');
-    }
-
-    if (!Array.isArray(ballots) || ballots.length === 0) {
-      errors.push('Ballots list must be a non-empty array');
-    }
-
-    if (errors.length > 0) {
-      return { valid: false, errors };
-    }
-
-    const candidateSet = new Set(candidates);
-
-    for (let i = 0; i < ballots.length; i++) {
-      const ballot = ballots[i];
-
-      if (!Array.isArray(ballot) || ballot.length === 0) {
-        errors.push(`Ballot ${i + 1}: must be a non-empty array`);
-        continue;
-      }
-
-      const seen = new Set();
-      for (const choice of ballot) {
-        if (!candidateSet.has(choice)) {
-          errors.push(`Ballot ${i + 1}: unknown candidate "${choice}"`);
-        }
-        if (seen.has(choice)) {
-          errors.push(`Ballot ${i + 1}: duplicate ranking for "${choice}"`);
-        }
-        seen.add(choice);
-      }
-    }
-
-    return { valid: errors.length === 0, errors };
-  }
-
   tabulate(candidates, ballots, seats = 1) {
     if (seats === 1) {
       return this._tabulateSingleWinner(candidates, ballots);
@@ -338,57 +298,6 @@ class IRVMethod extends VotingMethod {
     return this._buildResult(candidates, ballots, rounds, winners, false, exhaustedCount, seats);
   }
 
-  // Compute how many ballots rank each active candidate at each effective position
-  _computeRankDistribution(activeCandidates, ballots) {
-    const distribution = {};
-    const numActive = activeCandidates.size;
-    for (const c of activeCandidates) {
-      distribution[c] = new Array(numActive).fill(0);
-    }
-
-    for (const ballot of ballots) {
-      const ranking = Array.isArray(ballot)
-        ? ballot.filter(c => activeCandidates.has(c))
-        : ballot.ranking.filter(c => activeCandidates.has(c));
-
-      for (let i = 0; i < ranking.length; i++) {
-        distribution[ranking[i]][i]++;
-      }
-    }
-
-    return distribution;
-  }
-
-  _buildResult(candidates, ballots, rounds, winners, isTie, exhaustedBallots, seats) {
-    let summary;
-    if (isTie) {
-      if (winners.length > 0) {
-        summary = `Partial result: ${winners.join(', ')} elected. Remaining seats ended in a tie.`;
-      } else {
-        summary = 'The election ended in a tie. No winner could be determined.';
-      }
-    } else if (winners.length === 1) {
-      const finalRound = rounds[rounds.length - 1];
-      const winnerVotes = finalRound.tallies[winners[0]];
-      summary = `${winners[0]} wins with ${winnerVotes} votes in round ${rounds.length}.`;
-    } else {
-      summary = `${winners.length} seats filled: ${winners.join(', ')}.`;
-    }
-
-    return {
-      method: 'irv',
-      title: '',
-      winners,
-      seats,
-      isTie,
-      rounds,
-      summary,
-      totalBallots: ballots.length,
-      totalCandidates: candidates.length,
-      exhaustedBallots,
-      timestamp: '',
-    };
-  }
 }
 
 module.exports = IRVMethod;

--- a/src/voting/PreferentialBlockMethod.js
+++ b/src/voting/PreferentialBlockMethod.js
@@ -16,46 +16,6 @@ class PreferentialBlockMethod extends VotingMethod {
     super('preferential-block');
   }
 
-  validate(candidates, ballots) {
-    const errors = [];
-
-    if (!Array.isArray(candidates) || candidates.length === 0) {
-      errors.push('Candidates list must be a non-empty array');
-    }
-
-    if (!Array.isArray(ballots) || ballots.length === 0) {
-      errors.push('Ballots list must be a non-empty array');
-    }
-
-    if (errors.length > 0) {
-      return { valid: false, errors };
-    }
-
-    const candidateSet = new Set(candidates);
-
-    for (let i = 0; i < ballots.length; i++) {
-      const ballot = ballots[i];
-
-      if (!Array.isArray(ballot) || ballot.length === 0) {
-        errors.push(`Ballot ${i + 1}: must be a non-empty array`);
-        continue;
-      }
-
-      const seen = new Set();
-      for (const choice of ballot) {
-        if (!candidateSet.has(choice)) {
-          errors.push(`Ballot ${i + 1}: unknown candidate "${choice}"`);
-        }
-        if (seen.has(choice)) {
-          errors.push(`Ballot ${i + 1}: duplicate ranking for "${choice}"`);
-        }
-        seen.add(choice);
-      }
-    }
-
-    return { valid: errors.length === 0, errors };
-  }
-
   tabulate(candidates, ballots, seats = 1) {
     if (seats === 1) {
       return this._tabulateSingleWinner(candidates, ballots);
@@ -270,53 +230,6 @@ class PreferentialBlockMethod extends VotingMethod {
     return this._buildResult(candidates, ballots, rounds, winners, false, exhaustedCount, seats);
   }
 
-  _computeRankDistribution(activeCandidates, ballots) {
-    const distribution = {};
-    const numActive = activeCandidates.size;
-    for (const c of activeCandidates) {
-      distribution[c] = new Array(numActive).fill(0);
-    }
-    for (const ballot of ballots) {
-      const ranking = Array.isArray(ballot)
-        ? ballot.filter(c => activeCandidates.has(c))
-        : ballot.ranking.filter(c => activeCandidates.has(c));
-      for (let i = 0; i < ranking.length; i++) {
-        distribution[ranking[i]][i]++;
-      }
-    }
-    return distribution;
-  }
-
-  _buildResult(candidates, ballots, rounds, winners, isTie, exhaustedBallots, seats) {
-    let summary;
-    if (isTie) {
-      if (winners.length > 0) {
-        summary = `Partial result: ${winners.join(', ')} elected. Remaining seats ended in a tie.`;
-      } else {
-        summary = 'The election ended in a tie. No winner could be determined.';
-      }
-    } else if (winners.length === 1) {
-      const finalRound = rounds[rounds.length - 1];
-      const winnerVotes = finalRound.tallies[winners[0]];
-      summary = `${winners[0]} wins with ${winnerVotes} votes in round ${rounds.length}.`;
-    } else {
-      summary = `${winners.length} seats filled: ${winners.join(', ')}.`;
-    }
-
-    return {
-      method: 'preferential-block',
-      title: '',
-      winners,
-      seats,
-      isTie,
-      rounds,
-      summary,
-      totalBallots: ballots.length,
-      totalCandidates: candidates.length,
-      exhaustedBallots,
-      timestamp: '',
-    };
-  }
 }
 
 module.exports = PreferentialBlockMethod;

--- a/src/voting/VotingMethod.js
+++ b/src/voting/VotingMethod.js
@@ -7,11 +7,93 @@ class VotingMethod {
   }
 
   validate(candidates, ballots) {
-    throw new Error('validate() must be implemented by subclass');
+    const errors = [];
+
+    if (!Array.isArray(candidates) || candidates.length === 0) {
+      errors.push('Candidates list must be a non-empty array');
+    }
+
+    if (!Array.isArray(ballots) || ballots.length === 0) {
+      errors.push('Ballots list must be a non-empty array');
+    }
+
+    if (errors.length > 0) {
+      return { valid: false, errors };
+    }
+
+    const candidateSet = new Set(candidates);
+
+    for (let i = 0; i < ballots.length; i++) {
+      const ballot = ballots[i];
+
+      if (!Array.isArray(ballot) || ballot.length === 0) {
+        errors.push(`Ballot ${i + 1}: must be a non-empty array`);
+        continue;
+      }
+
+      const seen = new Set();
+      for (const choice of ballot) {
+        if (!candidateSet.has(choice)) {
+          errors.push(`Ballot ${i + 1}: unknown candidate "${choice}"`);
+        }
+        if (seen.has(choice)) {
+          errors.push(`Ballot ${i + 1}: duplicate ranking for "${choice}"`);
+        }
+        seen.add(choice);
+      }
+    }
+
+    return { valid: errors.length === 0, errors };
   }
 
   tabulate(candidates, ballots, seats = 1) {
     throw new Error('tabulate() must be implemented by subclass');
+  }
+
+  _buildResult(candidates, ballots, rounds, winners, isTie, exhaustedBallots, seats) {
+    let summary;
+    if (isTie) {
+      summary = winners.length > 0
+        ? `Partial result: ${winners.join(', ')} elected. Remaining seats ended in a tie.`
+        : 'The election ended in a tie. No winner could be determined.';
+    } else if (winners.length === 1) {
+      const finalRound = rounds[rounds.length - 1];
+      const winnerVotes = finalRound.tallies[winners[0]];
+      summary = `${winners[0]} wins with ${winnerVotes} votes in round ${rounds.length}.`;
+    } else {
+      summary = `${winners.length} seats filled: ${winners.join(', ')}.`;
+    }
+
+    return {
+      method: this.name,
+      title: '',
+      winners,
+      seats,
+      isTie,
+      rounds,
+      summary,
+      totalBallots: ballots.length,
+      totalCandidates: candidates.length,
+      exhaustedBallots,
+      timestamp: '',
+    };
+  }
+
+  _computeRankDistribution(activeCandidates, ballots) {
+    const distribution = {};
+    const numActive = activeCandidates instanceof Set ? activeCandidates.size : activeCandidates.length;
+    for (const c of activeCandidates) {
+      distribution[c] = new Array(numActive).fill(0);
+    }
+    for (const ballot of ballots) {
+      const ranking = Array.isArray(ballot)
+        ? ballot.filter(c => distribution[c] !== undefined)
+        : ballot.ranking.filter(c => distribution[c] !== undefined);
+      for (let i = 0; i < ranking.length; i++) {
+        distribution[ranking[i]][i]++;
+      }
+    }
+    return distribution;
   }
 }
 


### PR DESCRIPTION
- Move shared validate(), _buildResult(), and _computeRankDistribution() into VotingMethod base class, removing ~240 lines of duplicate code across IRVMethod, BordaCountMethod, and PreferentialBlockMethod
- Extract _computeScores() in BordaCountMethod to eliminate duplicate score calculation loop between single/multi-winner paths
- Remove stale backwards-compat fields from Borda result objects (isTieBreak, results, ballotCount, candidateCount)
- Extract CROWN_SVG constant in renderer.js (was inlined 5 times)
- Consolidate duplicate IRV round display logic into renderIRVRounds()